### PR TITLE
feat(actions): resolve bare XPath selectors via document.evaluate

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -4,6 +4,7 @@ module.exports = runAction;
 module.exports.isValidAction = isValidAction;
 module.exports.splitSelectorAndValue = splitSelectorAndValue;
 module.exports.usesNativeSelectorEngine = usesNativeSelectorEngine;
+module.exports.usesBareXPathEngine = usesBareXPathEngine;
 
 // Puppeteer resolves these non-CSS selector syntaxes natively (`aria/Name`,
 // `text/...`, `xpath/...`, `pierce/...`, and the `::-p-*` pseudo form, e.g.
@@ -24,6 +25,98 @@ function usesNativeSelectorEngine(selector) {
 		NATIVE_SELECTOR_PREFIXES.some(prefix => selector.startsWith(prefix)) ||
 		selector.includes('::-p-')
 	);
+}
+
+/**
+ * Whether a selector is a bare, standards-based XPath (`//…` or `/…`). Unlike
+ * the Puppeteer `xpath/` prefix above, a bare XPath is resolved with stock
+ * `document.evaluate` rather than Puppeteer's selector engine — so it adds no
+ * proprietary-engine dependency and resolves identically in any browser or
+ * frame. A CSS selector never starts with `/`, so the leading slash is an
+ * unambiguous marker.
+ * @param {String} selector
+ * @returns {Boolean}
+ */
+function usesBareXPathEngine(selector) {
+	return /^\s*\//.test(selector);
+}
+
+/**
+ * Resolve a bare XPath to a Puppeteer ElementHandle via `document.evaluate`
+ * (no Puppeteer xpath engine), throwing the standard "no element" action error
+ * when nothing matches. Caller owns disposal.
+ * @param {Object} page - A Puppeteer page object.
+ * @param {String} selector - A bare XPath selector.
+ * @returns {Promise<Object>} The resolved ElementHandle.
+ */
+async function resolveXPathHandle(page, selector) {
+	let handle = null;
+	try {
+		const jsHandle = await page.evaluateHandle(xpath => {
+			const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+			return result.singleNodeValue;
+		}, selector);
+		handle = jsHandle.asElement();
+		if (!handle) {
+			await jsHandle.dispose();
+		}
+	} catch {
+		handle = null;
+	}
+	if (!handle) {
+		throw new Error(`Failed action: no element matching selector "${selector}"`);
+	}
+	return handle;
+}
+
+/**
+ * Resolve a non-CSS selector to a Puppeteer ElementHandle: bare XPath via
+ * `document.evaluate`, every other native syntax via Puppeteer's engine.
+ * @param {Object} page - A Puppeteer page object.
+ * @param {String} selector - A bare-XPath or Puppeteer-native selector.
+ * @returns {Promise<Object>} The resolved ElementHandle.
+ */
+function resolveElementHandle(page, selector) {
+	if (usesBareXPathEngine(selector)) {
+		return resolveXPathHandle(page, selector);
+	}
+	return resolveNativeHandle(page, selector);
+}
+
+/**
+ * Wait for a bare-XPath element to reach the given state, polling
+ * `document.evaluate` in the page. Mirrors the CSS `document.querySelector`
+ * path's visibility definition (`offsetWidth`/`offsetHeight`/`getClientRects`)
+ * rather than Puppeteer's, since no Puppeteer selector engine is involved.
+ * @param {Object} page - A Puppeteer page object.
+ * @param {String} selector - A bare XPath selector.
+ * @param {String} state - One of added|removed|visible|hidden.
+ * @returns {Promise} Resolves once the state is reached; rejects on timeout.
+ */
+async function waitForXPathElementState(page, selector, state) {
+	const timeout = (typeof page.getDefaultTimeout === 'function' && page.getDefaultTimeout()) || 30000;
+	await page.waitForFunction((xpath, desiredState) => {
+		const element = document.evaluate(
+			xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
+		).singleNodeValue;
+		const isVisible = Boolean(
+			element &&
+			(element.offsetWidth || element.offsetHeight || element.getClientRects().length)
+		);
+		switch (desiredState) {
+			case 'added':
+				return Boolean(element);
+			case 'removed':
+				return !element;
+			case 'visible':
+				return isVisible;
+			case 'hidden':
+				return !isVisible;
+			default:
+				return false;
+		}
+	}, {polling: 200,
+		timeout}, selector, state);
 }
 
 /**
@@ -200,6 +293,19 @@ module.exports.actions = [
 		match: /^click( element)? (.+)$/i,
 		run: async (browser, page, options, matches) => {
 			const selector = matches[2];
+			// `page.click` handles CSS and every Puppeteer-native syntax, but not a
+			// bare XPath — resolve that to a handle via document.evaluate and click it.
+			if (usesBareXPathEngine(selector)) {
+				const handle = await resolveXPathHandle(page, selector);
+				try {
+					await handle.click();
+				} catch {
+					throw new Error(`Failed action: no element matching selector "${selector}"`);
+				} finally {
+					await handle.dispose();
+				}
+				return;
+			}
 			try {
 				await page.click(selector);
 			} catch {
@@ -221,8 +327,8 @@ module.exports.actions = [
 				throw new Error(`Failed action: cannot parse "set field <selector> to <value>" from "${matches[0]}"`);
 			}
 			const {selector, value} = split;
-			if (usesNativeSelectorEngine(selector)) {
-				const handle = await resolveNativeHandle(page, selector);
+			if (usesNativeSelectorEngine(selector) || usesBareXPathEngine(selector)) {
+				const handle = await resolveElementHandle(page, selector);
 				try {
 					await handle.evaluate((target, desiredValue) => {
 						if (target.tagName === 'SELECT') {
@@ -316,8 +422,8 @@ module.exports.actions = [
 		match: /^clear( field)? (.+?)$/i,
 		run: async (browser, page, options, matches) => {
 			const selector = matches[2];
-			if (usesNativeSelectorEngine(selector)) {
-				const handle = await resolveNativeHandle(page, selector);
+			if (usesNativeSelectorEngine(selector) || usesBareXPathEngine(selector)) {
+				const handle = await resolveElementHandle(page, selector);
 				try {
 					await handle.evaluate(target => {
 						const prototype = Object.getPrototypeOf(target);
@@ -371,8 +477,8 @@ module.exports.actions = [
 		run: async (browser, page, options, matches) => {
 			const checked = (matches[1] !== 'uncheck');
 			const selector = matches[3];
-			if (usesNativeSelectorEngine(selector)) {
-				const handle = await resolveNativeHandle(page, selector);
+			if (usesNativeSelectorEngine(selector) || usesBareXPathEngine(selector)) {
+				const handle = await resolveElementHandle(page, selector);
 				try {
 					await handle.evaluate((target, isChecked) => {
 						target.checked = isChecked;
@@ -473,6 +579,11 @@ module.exports.actions = [
 			const selector = matches[2];
 			const state = matches[4];
 
+			if (usesBareXPathEngine(selector)) {
+				await waitForXPathElementState(page, selector, state);
+				return;
+			}
+
 			if (usesNativeSelectorEngine(selector)) {
 				await waitForNativeElementState(page, selector, state);
 				return;
@@ -529,8 +640,8 @@ module.exports.actions = [
 			const selector = matches[2];
 			const eventType = matches[3];
 			/* eslint-disable no-underscore-dangle */
-			if (usesNativeSelectorEngine(selector)) {
-				const handle = await resolveNativeHandle(page, selector);
+			if (usesNativeSelectorEngine(selector) || usesBareXPathEngine(selector)) {
+				const handle = await resolveElementHandle(page, selector);
 				try {
 					await handle.evaluate((target, desiredEvent) => {
 						target.addEventListener(desiredEvent, () => {

--- a/test/unit/lib/action.test.js
+++ b/test/unit/lib/action.test.js
@@ -1883,6 +1883,28 @@ describe('lib/action', function() {
 				assert.isFalse(runAction.usesNativeSelectorEngine('button[aria-label="x"]'));
 			});
 
+			it('returns false for a bare XPath (it is not a Puppeteer-engine selector)', function() {
+				assert.isFalse(runAction.usesNativeSelectorEngine('//button[normalize-space(.)="Go"]'));
+			});
+
+		});
+
+		describe('.usesBareXPathEngine(selector)', function() {
+
+			it('returns true for bare XPath selectors', function() {
+				assert.isTrue(runAction.usesBareXPathEngine('//button[normalize-space(.)="Allow all cookies"]'));
+				assert.isTrue(runAction.usesBareXPathEngine('//*[@role="dialog"]//button'));
+				assert.isTrue(runAction.usesBareXPathEngine('/html/body/div[2]/button'));
+				assert.isTrue(runAction.usesBareXPathEngine('  //button'));
+			});
+
+			it('returns false for CSS and Puppeteer-native selectors', function() {
+				assert.isFalse(runAction.usesBareXPathEngine('#bar'));
+				assert.isFalse(runAction.usesBareXPathEngine('button[aria-label="x"]'));
+				assert.isFalse(runAction.usesBareXPathEngine('xpath///button'));
+				assert.isFalse(runAction.usesBareXPathEngine('::-p-aria(Go[role="button"])'));
+			});
+
 		});
 
 		describe('set-field-value with a native selector', function() {
@@ -2184,6 +2206,188 @@ describe('lib/action', function() {
 					assert.instanceOf(rejectedError, Error);
 					assert.strictEqual(rejectedError.message, `Failed action: no element matching selector "${selector}"`);
 					assert.called(puppeteer.mockElementHandle.dispose);
+				});
+			});
+		});
+
+	});
+
+	describe('bare XPath (document.evaluate) selector support', function() {
+
+		describe('click-element with a bare XPath', function() {
+			let action;
+			let matches;
+			const selector = '//button[normalize-space(.)="Allow all cookies"]';
+
+			beforeEach(async function() {
+				action = runAction.actions.find(foundAction => foundAction.name === 'click-element');
+				matches = `click element ${selector}`.match(action.match);
+				await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+			});
+
+			it('resolves a handle via evaluateHandle and clicks it, not page.click', function() {
+				assert.calledOnce(puppeteer.mockPage.evaluateHandle);
+				assert.strictEqual(puppeteer.mockPage.evaluateHandle.firstCall.args[1], selector);
+				assert.isFunction(puppeteer.mockPage.evaluateHandle.firstCall.args[0]);
+				assert.notCalled(puppeteer.mockPage.click);
+				assert.calledOnce(puppeteer.mockElementHandle.click);
+				assert.calledOnce(puppeteer.mockElementHandle.dispose);
+			});
+
+			describe('the page-side resolver function', function() {
+				let originalDocument;
+				let originalXPathResult;
+				let mockNode;
+				let result;
+
+				beforeEach(function() {
+					originalDocument = global.document;
+					originalXPathResult = global.XPathResult;
+					mockNode = {nodeType: 1};
+					global.XPathResult = {FIRST_ORDERED_NODE_TYPE: 9};
+					global.document = {
+						evaluate: sinon.stub().returns({singleNodeValue: mockNode})
+					};
+					result = puppeteer.mockPage.evaluateHandle.firstCall.args[0]('//button');
+				});
+
+				afterEach(function() {
+					global.document = originalDocument;
+					global.XPathResult = originalXPathResult;
+				});
+
+				it('evaluates the xpath and returns the first matching node', function() {
+					assert.calledWithExactly(global.document.evaluate, '//button', global.document, null, 9, null);
+					assert.strictEqual(result, mockNode);
+				});
+			});
+
+			describe('when no element matches the xpath', function() {
+				let rejectedError;
+
+				beforeEach(async function() {
+					puppeteer.mockJSHandle.asElement.returns(null);
+					try {
+						await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+					} catch (error) {
+						rejectedError = error;
+					}
+				});
+
+				it('disposes the JS handle and rejects with the standard no-element error', function() {
+					assert.instanceOf(rejectedError, Error);
+					assert.strictEqual(rejectedError.message, `Failed action: no element matching selector "${selector}"`);
+					assert.called(puppeteer.mockJSHandle.dispose);
+				});
+			});
+
+			describe('when the click fails', function() {
+				let rejectedError;
+
+				beforeEach(async function() {
+					puppeteer.mockElementHandle.click.rejects(new Error('click error'));
+					try {
+						await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+					} catch (error) {
+						rejectedError = error;
+					}
+				});
+
+				it('rejects with the standard no-element error and still disposes the handle', function() {
+					assert.instanceOf(rejectedError, Error);
+					assert.strictEqual(rejectedError.message, `Failed action: no element matching selector "${selector}"`);
+					assert.called(puppeteer.mockElementHandle.dispose);
+				});
+			});
+		});
+
+		describe('set-field-value with a bare XPath', function() {
+			let action;
+			const selector = '//input[@name="email"]';
+
+			beforeEach(async function() {
+				action = runAction.actions.find(foundAction => foundAction.name === 'set-field-value');
+				const matches = `set field ${selector} to bar`.match(action.match);
+				await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+			});
+
+			it('resolves via evaluateHandle and sets the value on the handle', function() {
+				assert.calledOnce(puppeteer.mockPage.evaluateHandle);
+				assert.notCalled(puppeteer.mockPage.$);
+				assert.notCalled(puppeteer.mockPage.evaluate);
+				assert.calledOnce(puppeteer.mockElementHandle.evaluate);
+				assert.strictEqual(puppeteer.mockElementHandle.evaluate.firstCall.args[1], 'bar');
+				assert.calledOnce(puppeteer.mockElementHandle.dispose);
+			});
+		});
+
+		describe('wait-for-element-state with a bare XPath', function() {
+			let action;
+			const selector = '//button[normalize-space(.)="Allow all cookies"]';
+
+			beforeEach(function() {
+				action = runAction.actions.find(foundAction => foundAction.name === 'wait-for-element-state');
+			});
+
+			it('waits via page.waitForFunction, not Puppeteer waitForSelector', async function() {
+				const matches = `wait for element ${selector} to be visible`.match(action.match);
+				await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+				assert.notCalled(puppeteer.mockPage.waitForSelector);
+				assert.calledOnce(puppeteer.mockPage.waitForFunction);
+				const {args} = puppeteer.mockPage.waitForFunction.firstCall;
+				assert.isFunction(args[0]);
+				assert.deepEqual(args[1], {polling: 200,
+					timeout: 30000});
+				assert.strictEqual(args[2], selector);
+				assert.strictEqual(args[3], 'visible');
+			});
+
+			describe('the page-side predicate', function() {
+				let originalDocument;
+				let originalXPathResult;
+				let predicate;
+
+				function stubElement(node) {
+					global.document = {
+						evaluate: sinon.stub().returns({singleNodeValue: node})
+					};
+				}
+
+				beforeEach(async function() {
+					originalDocument = global.document;
+					originalXPathResult = global.XPathResult;
+					global.XPathResult = {FIRST_ORDERED_NODE_TYPE: 9};
+					const matches = `wait for element ${selector} to be visible`.match(action.match);
+					await action.run(puppeteer.mockBrowser, puppeteer.mockPage, {}, matches);
+					predicate = puppeteer.mockPage.waitForFunction.firstCall.args[0];
+				});
+
+				afterEach(function() {
+					global.document = originalDocument;
+					global.XPathResult = originalXPathResult;
+				});
+
+				it('is true for "visible" when the element has layout boxes', function() {
+					stubElement({offsetWidth: 10,
+						offsetHeight: 10,
+						getClientRects: () => [{}]});
+					assert.isTrue(predicate(selector, 'visible'));
+				});
+
+				it('is false for "visible" when the element has no layout boxes', function() {
+					stubElement({offsetWidth: 0,
+						offsetHeight: 0,
+						getClientRects: () => []});
+					assert.isFalse(predicate(selector, 'visible'));
+				});
+
+				it('is true for "added" when the element exists and "removed" when it does not', function() {
+					stubElement({offsetWidth: 1,
+						offsetHeight: 1,
+						getClientRects: () => [{}]});
+					assert.isTrue(predicate(selector, 'added'));
+					stubElement(null);
+					assert.isTrue(predicate(selector, 'removed'));
 				});
 			});
 		});

--- a/test/unit/mocks/puppeteer.mock.js
+++ b/test/unit/mocks/puppeteer.mock.js
@@ -13,12 +13,22 @@ const mockBrowser = {
 };
 puppeteer.mockBrowser = mockBrowser;
 
-// ElementHandle returned by `page.$` for native (non-CSS) selector resolution.
+// ElementHandle returned by `page.$` for native (non-CSS) selector resolution,
+// and by `jsHandle.asElement()` for bare-XPath resolution.
 const mockElementHandle = {
 	evaluate: sinon.stub().resolves(),
+	click: sinon.stub().resolves(),
 	dispose: sinon.stub().resolves()
 };
 puppeteer.mockElementHandle = mockElementHandle;
+
+// JSHandle returned by `page.evaluateHandle` when resolving a bare XPath. Its
+// `asElement()` yields the ElementHandle (or null when nothing matched).
+const mockJSHandle = {
+	asElement: sinon.stub().returns(mockElementHandle),
+	dispose: sinon.stub().resolves()
+};
+puppeteer.mockJSHandle = mockJSHandle;
 
 const mockPage = {
 	addScriptTag: sinon.stub().resolves(),
@@ -37,6 +47,7 @@ const mockPage = {
 	type: sinon.stub().resolves(),
 	waitForFunction: sinon.stub().resolves(),
 	$: sinon.stub().resolves(mockElementHandle),
+	evaluateHandle: sinon.stub().resolves(mockJSHandle),
 	waitForSelector: sinon.stub().resolves(mockElementHandle),
 	getDefaultTimeout: sinon.stub().returns(30000)
 };


### PR DESCRIPTION
## Summary

Adds a bare-XPath resolution branch to element actions: when a selector is a bare `//…` XPath, resolve it via stock `document.evaluate(...).singleNodeValue` in page context — no Puppeteer selector engine required.

This is the pa11y side of the engine-agnostic selector work. It pairs with Wendy emitting `document.evaluate`-resolvable bare `//…` candidates, so the same selector resolves identically in the recorder, the CDP replayer, and the backend pa11y audit, and is human-inspectable / DevTools-pasteable.

The earlier DEV-921 `usesNativeSelectorEngine` patch already handles the Puppeteer `xpath/` / `text/` / `pierce/` prefixes; this adds the *bare* `//…` form, which removes a Puppeteer-engine dependency rather than adding one.

## Note on stacking

This branch is stacked on `fix/dev-921-aria-role-name-selectors` (PR #1). Until #1 merges to `main`, this PR's diff also shows the DEV-921 commit (`3bf0861`); once #1 lands it reduces to the single bare-XPath commit (`f7e92a7`).

Closes DEV-923