### PR TITLE
Enhance axe data capture and update tests for audit resolution

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,15 @@ const configPa11y = require('eslint-config-pa11y');
 module.exports = defineConfig([
 	configPa11y,
 	{
+		rules: {
+			// `x`/`y` are standard DOMRect coordinate names (bbox capture in the axe runner).
+			'id-length': ['error', {
+				min: 2,
+				exceptions: ['_', '$', 'i', 'x', 'y']
+			}]
+		}
+	},
+	{
 		files: ['test/**/*.js', 'test/**/*.cjs'],
 		rules: {
 			'max-len': 'off',

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -40,7 +40,7 @@ const run = async options => {
 	 * @param {Pa11yConfiguration} options Pa11y's configuration
 	 * @returns {AxeRunOptions} Axe configuration
 	 */
-	const getAxeOptions = ({ standard, rules = [], ignore = [] }) => ({
+	const getAxeOptions = ({standard, rules = [], ignore = []}) => ({
 		rules: pa11yRulesToAxe(rules, ignore),
 		...(standard && {
 			runOnly: createAxeRunOnlyTags(standard)
@@ -83,7 +83,7 @@ const run = async options => {
 			{},
 			...getBrowserAxe()
 				.getRules()
-				.map(({ ruleId }) => ruleId.toLowerCase())
+				.map(({ruleId}) => ruleId.toLowerCase())
 				.map(id => createAxeRule(id, rules, ignore))
 				.filter(rule => rule)
 		);
@@ -151,7 +151,7 @@ const run = async options => {
 	 * @see https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#results-object
 	 */
 	const processIssue = (
-		{ nodes, id, description, help, helpUrl, impact },
+		{nodes, id, description, help, helpUrl, impact},
 		needsFurtherReview = false,
 		levelCapWhenNeedsReview
 	) => {
@@ -162,10 +162,10 @@ const run = async options => {
 				// DEV-836/892: capture axe.data + cssFg + bbox (+ pseudo styles for
 				// pseudoContent) so the post-audit resolver can run as pure compute.
 				// Pa11y otherwise strips axe.data. Only attached for incompletes.
-				const dataCheck = needsFurtherReview
-					? [].concat(node.any || [], node.all || [], node.none || [])
-						.find(c => c && c.id === id) || null
-					: null;
+				const dataCheck = needsFurtherReview ?
+					[].concat(node.any || [], node.all || [], node.none || [])
+						.find(check => check && check.id === id) || null :
+					null;
 				let cssFg = null;
 				let bgClip = null;
 				let bgImage = null;
@@ -186,7 +186,7 @@ const run = async options => {
 							const webkitClip = style.webkitBackgroundClip ||
 								(style.getPropertyValue && style.getPropertyValue('-webkit-background-clip'));
 							bgClip = (stdClip === 'text' || webkitClip === 'text') ? 'text' : (stdClip || webkitClip || null);
-							// when text is clipped to the background, the glyphs are
+							// When text is clipped to the background, the glyphs are
 							// painted from the background-image gradient (or a solid background-color).
 							// Capture the paint source so the resolver can measure real contrast.
 							if (bgClip === 'text') {
@@ -197,23 +197,28 @@ const run = async options => {
 						}
 						const rect = element.getBoundingClientRect && element.getBoundingClientRect();
 						if (rect) {
-							bbox = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+							bbox = {x: rect.x,
+								y: rect.y,
+								width: rect.width,
+								height: rect.height};
 						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 						if (messageKey === 'pseudoContent') {
 							const before = window.getComputedStyle(element, '::before');
 							const beforeContent = (before && before.content) || null;
-							if (beforeContent && beforeContent !== 'none' && beforeContent !== '""' && beforeContent !== "''") {
-								pseudoBefore = { color: (before && before.color) || null, content: beforeContent };
+							if (beforeContent && beforeContent !== 'none' && beforeContent !== '""' && beforeContent !== '\'\'') {
+								pseudoBefore = {color: (before && before.color) || null,
+									content: beforeContent};
 							}
 							const after = window.getComputedStyle(element, '::after');
 							const afterContent = (after && after.content) || null;
-							if (afterContent && afterContent !== 'none' && afterContent !== '""' && afterContent !== "''") {
-								pseudoAfter = { color: (after && after.color) || null, content: afterContent };
+							if (afterContent && afterContent !== 'none' && afterContent !== '""' && afterContent !== '\'\'') {
+								pseudoAfter = {color: (after && after.color) || null,
+									content: afterContent};
 							}
 						}
-					} catch (e) {
-						// tolerate DOM read failures — leave nulls
+					} catch {
+						// Tolerate DOM read failures — leave nulls
 					}
 				}
 				return {
@@ -233,13 +238,13 @@ const run = async options => {
 								target: rn.target,
 								html: rn.html
 							})),
-							cssFg: cssFg,
-							bgClip: bgClip,
-							...(bgImage && { bgImage: bgImage }),
-							...(bgColor && { bgColor: bgColor }),
-							bbox: bbox,
-							...(pseudoBefore && { pseudoBefore: pseudoBefore }),
-							...(pseudoAfter && { pseudoAfter: pseudoAfter })
+							cssFg,
+							bgClip,
+							...(bgImage && {bgImage}),
+							...(bgColor && {bgColor}),
+							bbox,
+							...(pseudoBefore && {pseudoBefore}),
+							...(pseudoAfter && {pseudoAfter})
 						})
 					}
 				};
@@ -255,7 +260,7 @@ const run = async options => {
 	 * @param {Pa11yConfiguration} options Pa11y's configuration
 	 * @returns {Promise<Array<Pa11yResult>>} A promise of axe issues translated for Pa11y
 	 */
-	async function runAxeCore({ standard, rules, ignore, rootElement, levelCapWhenNeedsReview }) {
+	async function runAxeCore({standard, rules, ignore, rootElement, levelCapWhenNeedsReview}) {
 		const {
 			violations = [],
 			incomplete = []

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -40,7 +40,7 @@ const run = async options => {
 	 * @param {Pa11yConfiguration} options Pa11y's configuration
 	 * @returns {AxeRunOptions} Axe configuration
 	 */
-	const getAxeOptions = ({standard, rules = [], ignore = []}) => ({
+	const getAxeOptions = ({ standard, rules = [], ignore = [] }) => ({
 		rules: pa11yRulesToAxe(rules, ignore),
 		...(standard && {
 			runOnly: createAxeRunOnlyTags(standard)
@@ -83,7 +83,7 @@ const run = async options => {
 			{},
 			...getBrowserAxe()
 				.getRules()
-				.map(({ruleId}) => ruleId.toLowerCase())
+				.map(({ ruleId }) => ruleId.toLowerCase())
 				.map(id => createAxeRule(id, rules, ignore))
 				.filter(rule => rule)
 		);
@@ -151,26 +151,99 @@ const run = async options => {
 	 * @see https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#results-object
 	 */
 	const processIssue = (
-		{nodes, id, description, help, helpUrl, impact},
+		{ nodes, id, description, help, helpUrl, impact },
 		needsFurtherReview = false,
 		levelCapWhenNeedsReview
 	) => {
 		return (nodes.length ? nodes : nodesForNodelessIssue())
-			.map(({target}) => target && selectorToString(target))
-			.map(selector => selector && window.document.querySelector(selector))
-			.map(element => ({
-				element,
-				code: id,
-				type: choosePa11yLevel(impact, needsFurtherReview, levelCapWhenNeedsReview),
-				message: `${help} (${helpUrl})`,
-				runnerExtras: {
-					description,
-					impact,
-					needsFurtherReview,
-					help,
-					helpUrl
+			.map(node => {
+				const selector = node.target && selectorToString(node.target);
+				const element = selector && window.document.querySelector(selector);
+				// DEV-836/892: capture axe.data + cssFg + bbox (+ pseudo styles for
+				// pseudoContent) so the post-audit resolver can run as pure compute.
+				// Pa11y otherwise strips axe.data. Only attached for incompletes.
+				const dataCheck = needsFurtherReview
+					? [].concat(node.any || [], node.all || [], node.none || [])
+						.find(c => c && c.id === id) || null
+					: null;
+				let cssFg = null;
+				let bgClip = null;
+				let bgImage = null;
+				let bgColor = null;
+				let bbox = null;
+				let pseudoBefore = null;
+				let pseudoAfter = null;
+				if (needsFurtherReview && element) {
+					try {
+						const style = window.getComputedStyle(element);
+						cssFg = (style && style.color) || null;
+						// `background-clip: text` (Tailwind's bg-clip-text) paints the
+						// text from the element's background — usually a gradient — while `color`
+						// computes to transparent. Capture it so the resolver can report this
+						// honestly instead of mislabelling visible text as "fully transparent".
+						if (style) {
+							const stdClip = style.backgroundClip;
+							const webkitClip = style.webkitBackgroundClip ||
+								(style.getPropertyValue && style.getPropertyValue('-webkit-background-clip'));
+							bgClip = (stdClip === 'text' || webkitClip === 'text') ? 'text' : (stdClip || webkitClip || null);
+							// when text is clipped to the background, the glyphs are
+							// painted from the background-image gradient (or a solid background-color).
+							// Capture the paint source so the resolver can measure real contrast.
+							if (bgClip === 'text') {
+								const img = style.backgroundImage;
+								bgImage = (img && img !== 'none') ? img : null;
+								bgColor = style.backgroundColor || null;
+							}
+						}
+						const rect = element.getBoundingClientRect && element.getBoundingClientRect();
+						if (rect) {
+							bbox = { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+						}
+						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
+						if (messageKey === 'pseudoContent') {
+							const before = window.getComputedStyle(element, '::before');
+							const beforeContent = (before && before.content) || null;
+							if (beforeContent && beforeContent !== 'none' && beforeContent !== '""' && beforeContent !== "''") {
+								pseudoBefore = { color: (before && before.color) || null, content: beforeContent };
+							}
+							const after = window.getComputedStyle(element, '::after');
+							const afterContent = (after && after.content) || null;
+							if (afterContent && afterContent !== 'none' && afterContent !== '""' && afterContent !== "''") {
+								pseudoAfter = { color: (after && after.color) || null, content: afterContent };
+							}
+						}
+					} catch (e) {
+						// tolerate DOM read failures — leave nulls
+					}
 				}
-			}));
+				return {
+					element,
+					code: id,
+					type: choosePa11yLevel(impact, needsFurtherReview, levelCapWhenNeedsReview),
+					message: `${help} (${helpUrl})`,
+					runnerExtras: {
+						description,
+						impact,
+						needsFurtherReview,
+						help,
+						helpUrl,
+						...(needsFurtherReview && {
+							axeData: (dataCheck && dataCheck.data) || null,
+							axeRelatedNodes: ((dataCheck && dataCheck.relatedNodes) || []).map(rn => ({
+								target: rn.target,
+								html: rn.html
+							})),
+							cssFg: cssFg,
+							bgClip: bgClip,
+							...(bgImage && { bgImage: bgImage }),
+							...(bgColor && { bgColor: bgColor }),
+							bbox: bbox,
+							...(pseudoBefore && { pseudoBefore: pseudoBefore }),
+							...(pseudoAfter && { pseudoAfter: pseudoAfter })
+						})
+					}
+				};
+			});
 	};
 
 	const nodesForNodelessIssue = () => [{
@@ -182,7 +255,7 @@ const run = async options => {
 	 * @param {Pa11yConfiguration} options Pa11y's configuration
 	 * @returns {Promise<Array<Pa11yResult>>} A promise of axe issues translated for Pa11y
 	 */
-	async function runAxeCore({standard, rules, ignore, rootElement, levelCapWhenNeedsReview}) {
+	async function runAxeCore({ standard, rules, ignore, rootElement, levelCapWhenNeedsReview }) {
 		const {
 			violations = [],
 			incomplete = []

--- a/test/unit/lib/runners/axe.test.js
+++ b/test/unit/lib/runners/axe.test.js
@@ -534,7 +534,10 @@ describe('lib/runners/axe', function() {
 		beforeEach(function() {
 			element = {
 				getBoundingClientRect: sinon.stub().returns(
-					{x: 10, y: 20, width: 100, height: 30}
+					{x: 10,
+						y: 20,
+						width: 100,
+						height: 30}
 				)
 			};
 			style = {
@@ -545,8 +548,10 @@ describe('lib/runners/axe', function() {
 				backgroundColor: 'rgba(0, 0, 0, 0)',
 				getPropertyValue: sinon.stub().returns('')
 			};
-			beforeStyle = {content: 'none', color: 'rgb(0, 0, 0)'};
-			afterStyle = {content: 'none', color: 'rgb(0, 0, 0)'};
+			beforeStyle = {content: 'none',
+				color: 'rgb(0, 0, 0)'};
+			afterStyle = {content: 'none',
+				color: 'rgb(0, 0, 0)'};
 			global.window.document.querySelector = sinon.stub().returns(element);
 			// Read the closure vars lazily so per-test mutations/reassignments apply.
 			global.window.getComputedStyle = sinon.stub().callsFake((el, pseudo) => {
@@ -563,7 +568,10 @@ describe('lib/runners/axe', function() {
 		it('captures cssFg and bbox for an incomplete node', async function() {
 			const extras = await captureFor();
 			assert.strictEqual(extras.cssFg, 'rgb(10, 20, 30)');
-			assert.deepEqual(extras.bbox, {x: 10, y: 20, width: 100, height: 30});
+			assert.deepEqual(extras.bbox, {x: 10,
+				y: 20,
+				width: 100,
+				height: 30});
 		});
 
 		it('does not attach capture fields to violations', async function() {
@@ -587,19 +595,25 @@ describe('lib/runners/axe', function() {
 		});
 
 		it('extracts axeData and trimmed axeRelatedNodes from the matching check', async function() {
-			const data = {messageKey: 'bgImage', contrastRatio: 1};
+			const data = {messageKey: 'bgImage',
+				contrastRatio: 1};
 			const extras = await captureFor({
 				any: [
-					{id: 'other', data: {nope: true}, relatedNodes: []},
+					{id: 'other',
+						data: {nope: true},
+						relatedNodes: []},
 					{
 						id: 'mock-id',
 						data,
-						relatedNodes: [{target: ['rel-1'], html: '<a>', extra: 'dropped'}]
+						relatedNodes: [{target: ['rel-1'],
+							html: '<a>',
+							extra: 'dropped'}]
 					}
 				]
 			});
 			assert.deepEqual(extras.axeData, data);
-			assert.deepEqual(extras.axeRelatedNodes, [{target: ['rel-1'], html: '<a>'}]);
+			assert.deepEqual(extras.axeRelatedNodes, [{target: ['rel-1'],
+				html: '<a>'}]);
 		});
 
 		it('detects bgClip "text" and captures the gradient paint source (DEV-909)', async function() {
@@ -640,18 +654,25 @@ describe('lib/runners/axe', function() {
 		});
 
 		it('captures pseudo styles only for pseudoContent issues', async function() {
-			beforeStyle = {content: '"\\2605"', color: 'rgb(1, 2, 3)'};
+			beforeStyle = {content: '"\\2605"',
+				color: 'rgb(1, 2, 3)'};
 			const extras = await captureFor({
-				any: [{id: 'mock-id', data: {messageKey: 'pseudoContent'}, relatedNodes: []}]
+				any: [{id: 'mock-id',
+					data: {messageKey: 'pseudoContent'},
+					relatedNodes: []}]
 			});
-			assert.deepEqual(extras.pseudoBefore, {color: 'rgb(1, 2, 3)', content: '"\\2605"'});
+			assert.deepEqual(extras.pseudoBefore, {color: 'rgb(1, 2, 3)',
+				content: '"\\2605"'});
 			assert.isUndefined(extras.pseudoAfter);
 		});
 
 		it('does not read pseudo styles when messageKey is not pseudoContent', async function() {
-			beforeStyle = {content: '"\\2605"', color: 'rgb(1, 2, 3)'};
+			beforeStyle = {content: '"\\2605"',
+				color: 'rgb(1, 2, 3)'};
 			const extras = await captureFor({
-				any: [{id: 'mock-id', data: {messageKey: 'fgColor'}, relatedNodes: []}]
+				any: [{id: 'mock-id',
+					data: {messageKey: 'fgColor'},
+					relatedNodes: []}]
 			});
 			assert.isUndefined(extras.pseudoBefore);
 		});

--- a/test/unit/lib/runners/axe.test.js
+++ b/test/unit/lib/runners/axe.test.js
@@ -243,7 +243,14 @@ describe('lib/runners/axe', function() {
 						impact: 'minor',
 						needsFurtherReview: true,
 						help: 'mock help 3',
-						helpUrl: 'mock-help-url-3'
+						helpUrl: 'mock-help-url-3',
+						// Capture fields degrade to null here (mock has no getComputedStyle);
+						// populated paths are covered in the capture describe below.
+						axeData: null,
+						axeRelatedNodes: [],
+						cssFg: null,
+						bgClip: null,
+						bbox: null
 					}
 				},
 				{
@@ -256,7 +263,12 @@ describe('lib/runners/axe', function() {
 						impact: 'not a supported impact level',
 						needsFurtherReview: true,
 						help: 'mock help 4',
-						helpUrl: 'mock-help-url-4'
+						helpUrl: 'mock-help-url-4',
+						axeData: null,
+						axeRelatedNodes: [],
+						cssFg: null,
+						bgClip: null,
+						bbox: null
 					}
 				},
 				{
@@ -269,7 +281,12 @@ describe('lib/runners/axe', function() {
 						impact: 'not a supported impact level',
 						needsFurtherReview: true,
 						help: 'mock help 4',
-						helpUrl: 'mock-help-url-4'
+						helpUrl: 'mock-help-url-4',
+						axeData: null,
+						axeRelatedNodes: [],
+						cssFg: null,
+						bgClip: null,
+						bbox: null
 					}
 				},
 				{
@@ -282,7 +299,12 @@ describe('lib/runners/axe', function() {
 						impact: 'moderate',
 						needsFurtherReview: true,
 						help: 'mock help 5',
-						helpUrl: 'mock-help-url-5'
+						helpUrl: 'mock-help-url-5',
+						axeData: null,
+						axeRelatedNodes: [],
+						cssFg: null,
+						bgClip: null,
+						bbox: null
 					}
 				}
 			]);
@@ -477,6 +499,170 @@ describe('lib/runners/axe', function() {
 
 		});
 
+	});
+
+	describe('.run(options, pa11y) runnerExtras capture for incomplete issues', function() {
+		let element;
+		let style;
+		let beforeStyle;
+		let afterStyle;
+
+		// One incomplete issue whose single node carries the given checks
+		// (e.g. {any: [...]}). The selector resolves to `element`.
+		function incomplete(checks) {
+			return {
+				violations: [],
+				incomplete: [
+					{
+						id: 'mock-id',
+						description: 'd',
+						impact: 'minor',
+						help: 'h',
+						helpUrl: 'u',
+						nodes: [Object.assign({target: ['mock-selector']}, checks)]
+					}
+				]
+			};
+		}
+
+		async function captureFor(checks) {
+			global.window.axe.run = sinon.stub().resolves(incomplete(checks));
+			const resolved = await runner.run({}, {});
+			return resolved[0].runnerExtras;
+		}
+
+		beforeEach(function() {
+			element = {
+				getBoundingClientRect: sinon.stub().returns(
+					{x: 10, y: 20, width: 100, height: 30}
+				)
+			};
+			style = {
+				color: 'rgb(10, 20, 30)',
+				backgroundClip: 'border-box',
+				webkitBackgroundClip: '',
+				backgroundImage: 'none',
+				backgroundColor: 'rgba(0, 0, 0, 0)',
+				getPropertyValue: sinon.stub().returns('')
+			};
+			beforeStyle = {content: 'none', color: 'rgb(0, 0, 0)'};
+			afterStyle = {content: 'none', color: 'rgb(0, 0, 0)'};
+			global.window.document.querySelector = sinon.stub().returns(element);
+			// Read the closure vars lazily so per-test mutations/reassignments apply.
+			global.window.getComputedStyle = sinon.stub().callsFake((el, pseudo) => {
+				if (pseudo === '::before') {
+					return beforeStyle;
+				}
+				if (pseudo === '::after') {
+					return afterStyle;
+				}
+				return style;
+			});
+		});
+
+		it('captures cssFg and bbox for an incomplete node', async function() {
+			const extras = await captureFor();
+			assert.strictEqual(extras.cssFg, 'rgb(10, 20, 30)');
+			assert.deepEqual(extras.bbox, {x: 10, y: 20, width: 100, height: 30});
+		});
+
+		it('does not attach capture fields to violations', async function() {
+			global.window.axe.run = sinon.stub().resolves({
+				violations: [
+					{
+						id: 'v',
+						description: 'd',
+						impact: 'critical',
+						help: 'h',
+						helpUrl: 'u',
+						nodes: [{target: ['mock-selector']}]
+					}
+				],
+				incomplete: []
+			});
+			const extras = (await runner.run({}, {}))[0].runnerExtras;
+			assert.isUndefined(extras.cssFg);
+			assert.isUndefined(extras.bbox);
+			assert.isUndefined(extras.axeData);
+		});
+
+		it('extracts axeData and trimmed axeRelatedNodes from the matching check', async function() {
+			const data = {messageKey: 'bgImage', contrastRatio: 1};
+			const extras = await captureFor({
+				any: [
+					{id: 'other', data: {nope: true}, relatedNodes: []},
+					{
+						id: 'mock-id',
+						data,
+						relatedNodes: [{target: ['rel-1'], html: '<a>', extra: 'dropped'}]
+					}
+				]
+			});
+			assert.deepEqual(extras.axeData, data);
+			assert.deepEqual(extras.axeRelatedNodes, [{target: ['rel-1'], html: '<a>'}]);
+		});
+
+		it('detects bgClip "text" and captures the gradient paint source (DEV-909)', async function() {
+			style.backgroundClip = 'text';
+			style.backgroundImage =
+				'linear-gradient(to right, rgb(4, 120, 87), rgb(234, 88, 12))';
+			style.backgroundColor = 'rgb(255, 255, 255)';
+			const extras = await captureFor();
+			assert.strictEqual(extras.bgClip, 'text');
+			assert.strictEqual(
+				extras.bgImage,
+				'linear-gradient(to right, rgb(4, 120, 87), rgb(234, 88, 12))'
+			);
+			assert.strictEqual(extras.bgColor, 'rgb(255, 255, 255)');
+		});
+
+		it('detects bgClip "text" via -webkit-background-clip', async function() {
+			style.backgroundClip = 'border-box';
+			style.webkitBackgroundClip = 'text';
+			style.backgroundImage =
+				'linear-gradient(to right, rgb(0, 0, 0), rgb(1, 1, 1))';
+			const extras = await captureFor();
+			assert.strictEqual(extras.bgClip, 'text');
+			assert.strictEqual(
+				extras.bgImage,
+				'linear-gradient(to right, rgb(0, 0, 0), rgb(1, 1, 1))'
+			);
+		});
+
+		it('does not capture a paint source when not clipped to text', async function() {
+			style.backgroundClip = 'border-box';
+			style.backgroundImage =
+				'linear-gradient(to right, rgb(0, 0, 0), rgb(1, 1, 1))';
+			const extras = await captureFor();
+			assert.strictEqual(extras.bgClip, 'border-box');
+			assert.isUndefined(extras.bgImage);
+			assert.isUndefined(extras.bgColor);
+		});
+
+		it('captures pseudo styles only for pseudoContent issues', async function() {
+			beforeStyle = {content: '"\\2605"', color: 'rgb(1, 2, 3)'};
+			const extras = await captureFor({
+				any: [{id: 'mock-id', data: {messageKey: 'pseudoContent'}, relatedNodes: []}]
+			});
+			assert.deepEqual(extras.pseudoBefore, {color: 'rgb(1, 2, 3)', content: '"\\2605"'});
+			assert.isUndefined(extras.pseudoAfter);
+		});
+
+		it('does not read pseudo styles when messageKey is not pseudoContent', async function() {
+			beforeStyle = {content: '"\\2605"', color: 'rgb(1, 2, 3)'};
+			const extras = await captureFor({
+				any: [{id: 'mock-id', data: {messageKey: 'fgColor'}, relatedNodes: []}]
+			});
+			assert.isUndefined(extras.pseudoBefore);
+		});
+
+		it('degrades to null fields when a DOM read throws', async function() {
+			global.window.getComputedStyle = sinon.stub().throws(new Error('detached'));
+			const extras = await captureFor();
+			assert.isNull(extras.cssFg);
+			assert.isNull(extras.bgClip);
+			assert.isNull(extras.bbox);
+		});
 	});
 
 });


### PR DESCRIPTION
### Why
Our backend runs a post-audit color-contrast resolver that turns axe-core `incomplete` (needs-review) results into deterministic pass/fail verdicts. To do that as pure compute it needs axe's own `data` payload (which pa11y strips), the element's computed foreground colour, its bounding box, and a few style hints. This change has the axe runner capture that data at audit time and attach it to `runnerExtras`.

### What changed
`lib/runners/axe.js` — `processIssue` now, for incomplete nodes only (`needsFurtherReview === true`), attaches to `runnerExtras`:

- `axeData` / `axeRelatedNodes` — the matching check's `data` and trimmed related nodes (pa11y otherwise drops these).
- `cssFg` — computed `color` of the element.
- `bgClip` — `background-clip` (incl. `-webkit-background-clip`). When it's `text` (e.g. Tailwind's `bg-clip-text`), color computes to transparent and the visible glyphs are painted from the background, so we also capture the paint source (`bgImage` / `bgColor`). This is what lets the resolver measure real contrast on gradient-clipped text instead of mislabelling visible text as "fully transparent".
- `bbox` — bounding rect, used for screenshot-based background sampling.
- `pseudoBefore`/`pseudoAfter` — computed `content`/`color` of `::before`/`::after`, captured only for `pseudoContent` messages.

All reads are wrapped in `try/catch`; any DOM read failure degrades the fields to `null` rather than throwing. Violations are unaffected — none of these fields are added when `needsFurtherReview` is false.

