### PR TITLE
fix(actions): select controlled checkbox/radio via click (DEV-941)

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -481,8 +481,26 @@ module.exports.actions = [
 				const handle = await resolveElementHandle(page, selector);
 				try {
 					await handle.evaluate((target, isChecked) => {
-						target.checked = isChecked;
-						target.dispatchEvent(new Event('change', {bubbles: true}));
+						// Frameworks (e.g. React) derive a checkbox/radio's onChange from the
+						// click event, so setting `.checked` + a `change` event alone is ignored
+						// by controlled components. Click toggles the native state and fires the
+						// event they listen for; only when it can't (deselecting a radio, or a
+						// swallowed click) fall back to forcing the value via the native setter.
+						if (target.checked !== isChecked) {
+							target.click();
+						}
+						if (target.checked !== isChecked) {
+							const prototype = Object.getPrototypeOf(target);
+							const {set: setChecked} =
+								Object.getOwnPropertyDescriptor(prototype, 'checked') || {};
+							if (setChecked) {
+								setChecked.call(target, isChecked);
+							} else {
+								target.checked = isChecked;
+							}
+							target.dispatchEvent(new Event('input', {bubbles: true}));
+							target.dispatchEvent(new Event('change', {bubbles: true}));
+						}
 					}, checked);
 				} catch {
 					throw new Error(`Failed action: no element matching selector "${selector}"`);
@@ -497,10 +515,23 @@ module.exports.actions = [
 					if (!target) {
 						return Promise.reject(new Error('No element found'));
 					}
-					target.checked = isChecked;
-					target.dispatchEvent(new Event('change', {
-						bubbles: true
-					}));
+					// See the native-selector branch above for why this clicks rather than
+					// just setting `.checked`.
+					if (target.checked !== isChecked) {
+						target.click();
+					}
+					if (target.checked !== isChecked) {
+						const prototype = Object.getPrototypeOf(target);
+						const {set: setChecked} =
+							Object.getOwnPropertyDescriptor(prototype, 'checked') || {};
+						if (setChecked) {
+							setChecked.call(target, isChecked);
+						} else {
+							target.checked = isChecked;
+						}
+						target.dispatchEvent(new Event('input', {bubbles: true}));
+						target.dispatchEvent(new Event('change', {bubbles: true}));
+					}
 					return Promise.resolve();
 				}, selector, checked);
 			} catch {

--- a/test/unit/lib/action.test.js
+++ b/test/unit/lib/action.test.js
@@ -877,12 +877,12 @@ describe('lib/action', function() {
 				let originalDocument;
 
 				beforeEach(async function() {
-					mockElement = createMockElement();
+					mockElement = createMockElement({click: sinon.stub()});
 					originalDocument = global.document;
 					global.document = {
 						querySelector: sinon.stub().returns(mockElement)
 					};
-					resolvedValue = await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', 'mock-checked');
+					resolvedValue = await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', true);
 				});
 
 				afterEach(function() {
@@ -894,21 +894,54 @@ describe('lib/action', function() {
 					assert.calledWithExactly(global.document.querySelector, 'mock-selector');
 				});
 
-				it('sets the element `checked` property to the passed in checked value', function() {
-					assert.strictEqual(mockElement.checked, 'mock-checked');
+				it('clicks the element to drive a controlled change handler', function() {
+					assert.calledOnce(mockElement.click);
 				});
 
-				it('triggers a change event on the element', function() {
-					assert.calledOnce(Event);
-					assert.calledWithExactly(Event, 'change', {
-						bubbles: true
-					});
-					assert.calledOnce(mockElement.dispatchEvent);
-					assert.calledWithExactly(mockElement.dispatchEvent, mockEvent);
+				it('forces the value and dispatches input + change when the click does not settle it', function() {
+					// Mock click is a no-op, so checked stays unsettled and the fallback runs.
+					assert.strictEqual(mockElement.checked, true);
+					assert.calledTwice(Event);
+					assert.calledWithExactly(Event, 'input', {bubbles: true});
+					assert.calledWithExactly(Event, 'change', {bubbles: true});
+					assert.calledTwice(mockElement.dispatchEvent);
 				});
 
 				it('resolves with `undefined`', function() {
 					assert.isUndefined(resolvedValue);
+				});
+
+				describe('when the click settles the checked state', function() {
+					beforeEach(async function() {
+						Event.resetHistory();
+						mockElement = createMockElement();
+						mockElement.click = sinon.stub().callsFake(() => {
+							mockElement.checked = true;
+						});
+						global.document.querySelector.returns(mockElement);
+						await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', true);
+					});
+
+					it('does not fall back to forcing the value', function() {
+						assert.calledOnce(mockElement.click);
+						assert.notCalled(mockElement.dispatchEvent);
+						assert.notCalled(Event);
+					});
+				});
+
+				describe('when the element is already in the desired state', function() {
+					beforeEach(async function() {
+						Event.resetHistory();
+						mockElement = createMockElement({checked: true,
+							click: sinon.stub()});
+						global.document.querySelector.returns(mockElement);
+						await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', true);
+					});
+
+					it('neither clicks nor dispatches events', function() {
+						assert.notCalled(mockElement.click);
+						assert.notCalled(mockElement.dispatchEvent);
+					});
 				});
 
 				describe('when an element with the given selector cannot be found', function() {
@@ -917,7 +950,7 @@ describe('lib/action', function() {
 					beforeEach(async function() {
 						global.document.querySelector.returns(null);
 						try {
-							await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', 'mock-checked');
+							await puppeteer.mockPage.evaluate.firstCall.args[0]('mock-selector', true);
 						} catch (error) {
 							rejectedError = error;
 						}
@@ -926,9 +959,7 @@ describe('lib/action', function() {
 					it('rejects with an error', function() {
 						assert.instanceOf(rejectedError, Error);
 					});
-
 				});
-
 			});
 
 			it('resolves with `undefined`', function() {
@@ -2076,11 +2107,22 @@ describe('lib/action', function() {
 				assert.calledOnce(puppeteer.mockElementHandle.dispose);
 			});
 
-			it('sets checked and dispatches a change event when the function runs', async function() {
-				const mockElement = createMockElement();
+			it('clicks then forces the value when the click does not settle it', async function() {
+				const mockElement = createMockElement({click: sinon.stub()});
 				await puppeteer.mockElementHandle.evaluate.firstCall.args[0](mockElement, true);
+				assert.calledOnce(mockElement.click);
 				assert.strictEqual(mockElement.checked, true);
 				assert.calledWithExactly(mockElement.dispatchEvent, mockEvent);
+			});
+
+			it('relies on the click alone when it settles the checked state', async function() {
+				const mockElement = createMockElement();
+				mockElement.click = sinon.stub().callsFake(() => {
+					mockElement.checked = true;
+				});
+				await puppeteer.mockElementHandle.evaluate.firstCall.args[0](mockElement, true);
+				assert.calledOnce(mockElement.click);
+				assert.notCalled(mockElement.dispatchEvent);
 			});
 		});
 


### PR DESCRIPTION
## Summary

The `check field` / `uncheck field` action toggled inputs by setting `element.checked` and dispatching a `change` event. **Controlled components ignore this** — React (and frameworks like it) derive a checkbox/radio's `onChange` from the **click** event, not `change`. So auditing a workflow that selects a React/MUI radio or checkbox left the control unselected, the dependent UI (e.g. a submit button) never appeared, and the next `wait for element … to be visible` timed out.

This is the audit-side counterpart to the same fix already verified in the DevAlly recorder/replayer (the Chrome extension), which audits run through `pa11y-unlimited`.

## Change

`check-field` now toggles the way a real user does:

- **Click** the element when its state needs to change — this performs the native toggle and fires the click → input → change sequence frameworks key `onChange` off.
- **Fall back** to forcing the value via the native `checked` setter + `input`/`change` only when a click can't achieve the desired state (deselecting a radio, or a click swallowed by the page).
- Guarded on `checked !== desired`, so an already-correct control isn't toggled off.

Applied to **both** selector paths (native `::-p-aria(...)`/XPath via the element handle, and CSS via `document.querySelector`).

## Tests

- New unit tests for both paths covering: the click being issued, the native-setter fallback when the click doesn't settle the state, the click-only path when it does, and the already-in-desired-state no-op.
- Full suite: **451 passing**, lint clean (0 errors), coverage gate (90% lines/functions/branches) satisfied.

Closes DEV-941