### PR TITLE
fix(runner): enhance opacity handling for text rendering in audits

### DIFF
--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -159,9 +159,8 @@ const run = async options => {
 			.map(node => {
 				const selector = node.target && selectorToString(node.target);
 				const element = selector && window.document.querySelector(selector);
-				// DEV-836/892: capture axe.data + cssFg + bbox (+ pseudo styles for
-				// pseudoContent) so the post-audit resolver can run as pure compute.
-				// Pa11y otherwise strips axe.data. Only attached for incompletes.
+				// DEV-836/892: capture axe.data + cssFg + bbox (+ pseudo styles) on incompletes
+				// so the post-audit resolver runs as pure compute. Pa11y otherwise strips axe.data.
 				const dataCheck = needsFurtherReview ?
 					[].concat(node.any || [], node.all || [], node.none || [])
 						.find(check => check && check.id === id) || null :
@@ -173,22 +172,21 @@ const run = async options => {
 				let bbox = null;
 				let pseudoBefore = null;
 				let pseudoAfter = null;
+				let opacity = 1;
 				if (needsFurtherReview && element) {
 					try {
 						const style = window.getComputedStyle(element);
 						cssFg = (style && style.color) || null;
-						// `background-clip: text` (Tailwind's bg-clip-text) paints the
-						// text from the element's background — usually a gradient — while `color`
-						// computes to transparent. Capture it so the resolver can report this
-						// honestly instead of mislabelling visible text as "fully transparent".
+						// `background-clip: text` paints glyphs from the background while `color`
+						// computes to transparent — capture it so the resolver doesn't mislabel
+						// visible text as fully transparent.
 						if (style) {
 							const stdClip = style.backgroundClip;
 							const webkitClip = style.webkitBackgroundClip ||
 								(style.getPropertyValue && style.getPropertyValue('-webkit-background-clip'));
 							bgClip = (stdClip === 'text' || webkitClip === 'text') ? 'text' : (stdClip || webkitClip || null);
-							// When text is clipped to the background, the glyphs are
-							// painted from the background-image gradient (or a solid background-color).
-							// Capture the paint source so the resolver can measure real contrast.
+							// Clipped text is painted from the background-image/colour — capture the
+							// paint source so the resolver can measure real contrast.
 							if (bgClip === 'text') {
 								const img = style.backgroundImage;
 								bgImage = (img && img !== 'none') ? img : null;
@@ -201,6 +199,18 @@ const run = async options => {
 								y: rect.y,
 								width: rect.width,
 								height: rect.height};
+						}
+						// DEV-916/912: element or ancestor opacity fades the rendered text below its
+						// CSS `color`. Multiply opacity up the chain so the resolver can fold the
+						// cumulative value into the foreground alpha before measuring contrast.
+						let ancestor = element;
+						while (ancestor && ancestor.nodeType === 1) {
+							const ancestorStyle = window.getComputedStyle(ancestor);
+							const ancestorOpacity = ancestorStyle ? parseFloat(ancestorStyle.opacity) : NaN;
+							if (Number.isFinite(ancestorOpacity)) {
+								opacity *= ancestorOpacity;
+							}
+							ancestor = ancestor.parentElement;
 						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 						if (messageKey === 'pseudoContent') {
@@ -243,6 +253,7 @@ const run = async options => {
 							...(bgImage && {bgImage}),
 							...(bgColor && {bgColor}),
 							bbox,
+							...(opacity < 1 && {opacity}),
 							...(pseudoBefore && {pseudoBefore}),
 							...(pseudoAfter && {pseudoAfter})
 						})

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -200,9 +200,8 @@ const run = async options => {
 								width: rect.width,
 								height: rect.height};
 						}
-						// DEV-916/912: element or ancestor opacity fades the rendered text below its
-						// CSS `color`. Multiply opacity up the chain so the resolver can fold the
-						// cumulative value into the foreground alpha before measuring contrast.
+						// element/ancestor opacity fades the text below its CSS `color`.
+						// Multiply up the chain so the resolver folds it into the fg alpha.
 						let ancestor = element;
 						while (ancestor && ancestor.nodeType === 1) {
 							const ancestorStyle = window.getComputedStyle(ancestor);
@@ -214,17 +213,23 @@ const run = async options => {
 						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 						if (messageKey === 'pseudoContent') {
+							// a pseudo carries its own opacity on top of the element-chain
+							// `opacity` above (pseudos aren't in the parentElement walk) — capture it when < 1.
 							const before = window.getComputedStyle(element, '::before');
 							const beforeContent = (before && before.content) || null;
 							if (beforeContent && beforeContent !== 'none' && beforeContent !== '""' && beforeContent !== '\'\'') {
+								const beforeOpacity = before ? parseFloat(before.opacity) : NaN;
 								pseudoBefore = {color: (before && before.color) || null,
-									content: beforeContent};
+									content: beforeContent,
+									...(Number.isFinite(beforeOpacity) && beforeOpacity < 1 && {opacity: beforeOpacity})};
 							}
 							const after = window.getComputedStyle(element, '::after');
 							const afterContent = (after && after.content) || null;
 							if (afterContent && afterContent !== 'none' && afterContent !== '""' && afterContent !== '\'\'') {
+								const afterOpacity = after ? parseFloat(after.opacity) : NaN;
 								pseudoAfter = {color: (after && after.color) || null,
-									content: afterContent};
+									content: afterContent,
+									...(Number.isFinite(afterOpacity) && afterOpacity < 1 && {opacity: afterOpacity})};
 							}
 						}
 					} catch {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capture cumulative opacity from elements, ancestors, and pseudo-elements in the `axe` runner so contrast checks use the real rendered alpha. Addresses Linear DEV-916/912 and reduces false positives for faded text and `background-clip: text`.

- **Bug Fixes**
  - Multiply DOM-chain opacity and attach `opacity` when < 1; include `::before`/`::after` opacity when present.
  - Avoid mislabeling visible or faded text (incl. pseudo-content) as transparent, improving contrast accuracy.

<sup>Written for commit d89decf94bbc50e4e740cf3a71d2fa4e73051248. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/darrenbritton/pa11y-unlimited/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

