### PR TITLE
Feat/dev 916 912 opacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.5.1 (2026-06-30)
+
+* Capture cumulative element/ancestor `opacity` on incomplete nodes — multiplied up the DOM chain — and each `::before`/`::after` pseudo-element's own opacity, so the post-audit colour-contrast resolver folds faded text into the foreground alpha instead of over-rating low-opacity text as a pass. (DEV-916, DEV-912)
+
+### Full diff for `pa11y-unlimited@9.5.1`
+
+* [v9.5.0...v9.5.1](https://github.com/darrenbritton/pa11y-unlimited/compare/v9.5.0...v9.5.1)
+
 ## 9.5.0 (2026-06-16)
 
 * Drive actions through iframes during audits: element actions (`click`, `set field`, `clear field`, `check field`) resolve in the child frame that holds the selector, and `wait for element` polls across frames — including a frame attached mid-wait — so an audit can progress past controls hosted in an iframe such as an embedded login. (#9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## 9.5.1 (2026-06-30)
+## 9.6.0 (2026-06-30)
 
 * Capture cumulative element/ancestor `opacity` on incomplete nodes — multiplied up the DOM chain — and each `::before`/`::after` pseudo-element's own opacity, so the post-audit colour-contrast resolver folds faded text into the foreground alpha instead of over-rating low-opacity text as a pass. (DEV-916, DEV-912)
 
-### Full diff for `pa11y-unlimited@9.5.1`
+### Full diff for `pa11y-unlimited@9.6.0`
 
-* [v9.5.0...v9.5.1](https://github.com/darrenbritton/pa11y-unlimited/compare/v9.5.0...v9.5.1)
+* [v9.5.0...v9.6.0](https://github.com/darrenbritton/pa11y-unlimited/compare/v9.5.0...v9.6.0)
 
 ## 9.5.0 (2026-06-16)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-unlimited",
-  "version": "9.5.1",
+  "version": "9.6.0",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "a11y",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve color contrast accuracy by capturing cumulative opacity for elements and pseudo-elements, then folding it into the foreground alpha so faded text isn’t misrated as a pass. Bumps `pa11y-unlimited` to 9.6.0 with a new `runnerExtra.opacity` output. Addresses DEV-916 and DEV-912.

- New Features
  - Capture element/ancestor opacity (including `::before`/`::after`) on incomplete nodes.
  - Expose `runnerExtra.opacity` for the post-audit contrast resolver.

<sup>Written for commit 24cadc1c34535a83b8e7c9af525da2dc51967f1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/darrenbritton/pa11y-unlimited/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

