### PR TITLE
fix(runner): add placeholder color and opacity handling in audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.6.1 (2026-06-30)
+
+* Capture the `::placeholder` colour (and its own opacity) for an empty `<input>`/`<textarea>` — where the placeholder is the only visible text and the element's `color` styles the never-painted typed value — so the post-audit colour-contrast resolver measures the visible placeholder instead of false-passing on the unpainted `color`. (DEV-917)
+
+### Full diff for `pa11y-unlimited@9.6.1`
+
+* [v9.6.0...v9.6.1](https://github.com/darrenbritton/pa11y-unlimited/compare/v9.6.0...v9.6.1)
+
 ## 9.6.0 (2026-06-30)
 
 * Capture cumulative element/ancestor `opacity` on incomplete nodes — multiplied up the DOM chain — and each `::before`/`::after` pseudo-element's own opacity, so the post-audit colour-contrast resolver folds faded text into the foreground alpha instead of over-rating low-opacity text as a pass. (DEV-916, DEV-912)

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -173,6 +173,8 @@ const run = async options => {
 				let pseudoBefore = null;
 				let pseudoAfter = null;
 				let opacity = 1;
+				let placeholderColor = null;
+				let placeholderOpacity = 1;
 				if (needsFurtherReview && element) {
 					try {
 						const style = window.getComputedStyle(element);
@@ -210,6 +212,21 @@ const run = async options => {
 								opacity *= ancestorOpacity;
 							}
 							ancestor = ancestor.parentElement;
+						}
+						// an empty input/textarea paints only its ::placeholder; `color` styles the
+						// unpainted typed value. Capture its colour (and its own opacity) as the foreground.
+						if (id === 'color-contrast') {
+							const tag = element.tagName;
+							const showsPlaceholder =
+								(tag === 'INPUT' || tag === 'TEXTAREA') && !element.value && Boolean(element.placeholder);
+							if (showsPlaceholder) {
+								const ph = window.getComputedStyle(element, '::placeholder');
+								placeholderColor = (ph && ph.color) || null;
+								const phOpacity = ph ? parseFloat(ph.opacity) : NaN;
+								if (Number.isFinite(phOpacity)) {
+									placeholderOpacity = phOpacity;
+								}
+							}
 						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 						if (messageKey === 'pseudoContent') {
@@ -254,6 +271,8 @@ const run = async options => {
 								html: rn.html
 							})),
 							cssFg,
+							...(placeholderColor && {placeholderColor}),
+							...(placeholderOpacity < 1 && {placeholderOpacity}),
 							bgClip,
 							...(bgImage && {bgImage}),
 							...(bgColor && {bgColor}),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-unlimited",
-  "version": "9.6.0",
+  "version": "9.6.1",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "a11y",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes inaccurate color-contrast audits for empty inputs and textareas by capturing `::placeholder` color and opacity, so contrast is measured against the placeholder users actually see. Addresses Linear DEV-917.

- **Bug Fixes**
  - For `color-contrast`, when an `input`/`textarea` is empty with a placeholder, read `::placeholder` computed `color` and `opacity`.
  - Include `placeholderColor` and, if < 1, `placeholderOpacity` in the audit payload.

- **Dependencies**
  - Bump `pa11y-unlimited` to `9.6.1` and update the changelog.

<sup>Written for commit a46aee0beab85fcf61058f6d85b3ff4f22c17e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/darrenbritton/pa11y-unlimited/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

