### PR TITLE
feat(runner): enhance background detection for color-contrast audits

### DIFF
--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -317,16 +317,19 @@ const run = async options => {
 									if (!(el === element || element.contains(el))) {
 										const type = mediaTypeForTag(el.tagName);
 										if (type) {
-											return {type,
-												el};
-										}
-										const layer = classify(window.getComputedStyle(el));
-										if (layer === 'image') {
-											return {type: 'image',
-												el: null};
-										}
-										if (layer === 'occlude') {
-											return null;
+											if (isRendered(el)) {
+												return {type,
+													el};
+											}
+										} else {
+											const layer = classify(window.getComputedStyle(el));
+											if (layer === 'image') {
+												return {type: 'image',
+													el: null};
+											}
+											if (layer === 'occlude') {
+												return null;
+											}
 										}
 									}
 								}
@@ -378,7 +381,6 @@ const run = async options => {
 							}
 							// Tier 1: loading/deferred tells in the initial DOM (no scroll), only when no media was
 							// pinned. Abstain so a skeleton crop cannot drive a false pass.
-							// only when no covering media element was pinned above. The resolver abstains
 							if (!bgImageBehind) {
 								// Aria-busy on the text or an ancestor: the ARIA standard for a loading/updating region.
 								for (let anc = element; anc && anc !== window.document.documentElement; anc = anc.parentElement) {
@@ -389,7 +391,6 @@ const run = async options => {
 								}
 								// A lazy-load placeholder covering the text (loading=lazy not loaded, or a
 								// data-src/data-srcset marker whose real asset hasn't swapped in).
-								// marker (data-src/data-srcset) whose real asset hasn't swapped in — bgMediaReady can't see the
 								if (!bgDynamicSignal && bbox && bbox.width > 0 && bbox.height > 0) {
 									const dcx = bbox.x + (bbox.width / 2);
 									const dcy = bbox.y + (bbox.height / 2);
@@ -420,7 +421,6 @@ const run = async options => {
 							}
 							// Tier 2: unmarked media-slot skeleton — a solid full-tile placeholder behind the text
 							// (bgGradient/bgImage incomplete) with no marking attribute; detect the shape.
-							// initial load the tile has a SOLID placeholder slot behind the text plus a gradient overlay,
 							if (!bgImageBehind && !bgDynamicSignal && bbox && bbox.width > 0 && bbox.height > 0) {
 								const mk2 = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 								if (mk2 === 'bgGradient' || mk2 === 'bgImage') {

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -159,7 +159,7 @@ const run = async options => {
 			.map(node => {
 				const selector = node.target && selectorToString(node.target);
 				const element = selector && window.document.querySelector(selector);
-				// DEV-836/892: capture axe.data + cssFg + bbox (+ pseudo styles) on incompletes
+				// Capture axe.data + cssFg + bbox (+ pseudo styles) on incompletes
 				// so the post-audit resolver runs as pure compute. Pa11y otherwise strips axe.data.
 				const dataCheck = needsFurtherReview ?
 					[].concat(node.any || [], node.all || [], node.none || [])
@@ -169,6 +169,14 @@ const run = async options => {
 				let bgClip = null;
 				let bgImage = null;
 				let bgColor = null;
+				let bgImageBehind = null;
+				let bgMediaType = null;
+				let bgMediaReady = null;
+				// Tier 1 dynamic-content signal ('aria-busy' | 'lazy-attr'), else null.
+				let bgDynamicSignal = null;
+				// Stamped on every color-contrast item so a missing bgMediaType is unambiguous.
+				// Bump when the detection algorithm changes.
+				let bgDetectVersion = null;
 				let bbox = null;
 				let pseudoBefore = null;
 				let pseudoAfter = null;
@@ -228,6 +236,229 @@ const run = async options => {
 								}
 							}
 						}
+						// Detect a raster/media background behind the text (img/video/canvas or url()),
+						// stopping at the first opaque layer so deeper textures don't wrongly flag it.
+						if (id === 'color-contrast') {
+							bgDetectVersion = 'geom-1';
+							const isOpaqueColor = style => {
+								const bc = style && style.backgroundColor;
+								if (!bc) {
+									return false;
+								}
+								const match = bc.match(/rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(?:,\s*([\d.]+))?\)/);
+								return Boolean(match) && (match[1] === undefined || parseFloat(match[1]) >= 1);
+							};
+							// A gradient occludes only if every stop is fully opaque; a `transparent`
+							// keyword or an rgba()/hsla() stop with alpha < 1 lets the layer behind through.
+							const gradientIsOpaque = bi => {
+								if (/\btransparent\b/.test(bi)) {
+									return false;
+								}
+								const stops = bi.match(/rgba?\([^)]*\)|hsla?\([^)]*\)/g) || [];
+								return !stops.some(stop => {
+									// Alpha is the value after a slash, or the 4th comma component of rgba()/hsla();
+									// rgb()/hsl() (3 components) are opaque - do not read the last channel as alpha.
+									const match =
+										stop.match(/\/\s*([\d.]+%?)\s*\)$/) ||
+										stop.match(/^(?:rgba|hsla)\(\s*[\d.]+%?\s*,\s*[\d.]+%?\s*,\s*[\d.]+%?\s*,\s*([\d.]+%?)\s*\)$/i);
+									return match && parseFloat(match[1]) < (match[1].indexOf('%') === -1 ? 1 : 100);
+								});
+							};
+							// 'image' = raster/media (flag + occludes), 'occlude' = solid colour or opaque
+							// gradient (occludes, don't flag), 'continue' = see-through, keep looking deeper.
+							const classify = style => {
+								const bi = style && style.backgroundImage;
+								if (bi && bi !== 'none') {
+									if (bi.indexOf('url(') !== -1) {
+										return 'image';
+									}
+									return gradientIsOpaque(bi) ? 'occlude' : 'continue';
+								}
+								return isOpaqueColor(style) ? 'occlude' : 'continue';
+							};
+							// Ancestor chain: nearest painted background wins.
+							for (let anc = element; anc && anc !== window.document.documentElement; anc = anc.parentElement) {
+								const layer = classify(window.getComputedStyle(anc));
+								if (layer === 'image') {
+									bgImageBehind = true;
+									bgMediaType = 'image';
+								}
+								if (layer !== 'continue') {
+									break;
+								}
+							}
+							// Stacking: catch positioned img/video/canvas the ancestor walk misses (e.g. a
+							// sibling video); video/canvas may be an unloaded frame at capture time.
+							const mediaTypeForTag = tag =>
+								({IMG: 'image',
+									VIDEO: 'video',
+									CANVAS: 'canvas'})[tag] || null;
+							const rectCovers = (rect, x, y) =>
+								Boolean(rect) && rect.width > 0 && rect.height > 0 && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+							const isRendered = el => {
+								const style = window.getComputedStyle(el);
+								return style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity || '1') > 0;
+							};
+							// Loaded state of the covering media (img complete / video readyState>=2 / else ready).
+							const mediaReady = el => {
+								if (el.tagName === 'IMG') {
+									return Boolean(el.complete && el.naturalWidth > 0);
+								}
+								if (el.tagName === 'VIDEO') {
+									return el.readyState >= 2;
+								}
+								return true;
+							};
+							// In-viewport hit-testing: walk the paint stack; the first opaque layer occludes.
+							// Returns { type, el } (el null for a url() background) or null.
+							const detectByStack = (x, y) => {
+								const stack = window.document.elementsFromPoint(x, y) || [];
+								for (const el of stack) {
+									if (!(el === element || element.contains(el))) {
+										const type = mediaTypeForTag(el.tagName);
+										if (type) {
+											return {type,
+												el};
+										}
+										const layer = classify(window.getComputedStyle(el));
+										if (layer === 'image') {
+											return {type: 'image',
+												el: null};
+										}
+										if (layer === 'occlude') {
+											return null;
+										}
+									}
+								}
+								return null;
+							};
+							// Off-screen fallback: elementsFromPoint is viewport-only, so walk up from the text,
+							// checking each container's media for one whose rect covers the point, up to the clip.
+							const detectByGeometry = (x, y) => {
+								let anc = element.parentElement;
+								let hops = 0;
+								while (anc && hops < 12) {
+									const media = anc.querySelectorAll('img, video, canvas');
+									for (const node of media) {
+										const usable = !(node === element || element.contains(node) || node.contains(element) || !isRendered(node));
+										if (usable && rectCovers(node.getBoundingClientRect(), x, y)) {
+											return {type: mediaTypeForTag(node.tagName),
+												el: node};
+										}
+									}
+									if (anc === window.document.body) {
+										break;
+									}
+									const {overflow} = window.getComputedStyle(anc);
+									if (overflow && overflow !== 'visible') {
+										break;
+									}
+									anc = anc.parentElement;
+									hops += 1;
+								}
+								return null;
+							};
+							if (!bgImageBehind && bbox && bbox.width > 0 && bbox.height > 0) {
+								const cy = bbox.y + (bbox.height / 2);
+								const pts = [
+									[bbox.x + (bbox.width / 2), cy],
+									[bbox.x + (bbox.width * 0.25), cy],
+									[bbox.x + (bbox.width * 0.75), cy]
+								];
+								const inViewport = (x, y) => x >= 0 && y >= 0 && x <= window.innerWidth && y <= window.innerHeight;
+								for (const pt of pts) {
+									const hit = inViewport(pt[0], pt[1]) ? detectByStack(pt[0], pt[1]) : detectByGeometry(pt[0], pt[1]);
+									if (hit && hit.type) {
+										bgImageBehind = true;
+										bgMediaType = hit.type;
+										bgMediaReady = hit.el ? mediaReady(hit.el) : null;
+										break;
+									}
+								}
+							}
+							// Tier 1: loading/deferred tells in the initial DOM (no scroll), only when no media was
+							// pinned. Abstain so a skeleton crop cannot drive a false pass.
+							// only when no covering media element was pinned above. The resolver abstains
+							if (!bgImageBehind) {
+								// Aria-busy on the text or an ancestor: the ARIA standard for a loading/updating region.
+								for (let anc = element; anc && anc !== window.document.documentElement; anc = anc.parentElement) {
+									if (anc.getAttribute && anc.getAttribute('aria-busy') === 'true') {
+										bgDynamicSignal = 'aria-busy';
+										break;
+									}
+								}
+								// A lazy-load placeholder covering the text (loading=lazy not loaded, or a
+								// data-src/data-srcset marker whose real asset hasn't swapped in).
+								// marker (data-src/data-srcset) whose real asset hasn't swapped in — bgMediaReady can't see the
+								if (!bgDynamicSignal && bbox && bbox.width > 0 && bbox.height > 0) {
+									const dcx = bbox.x + (bbox.width / 2);
+									const dcy = bbox.y + (bbox.height / 2);
+									let anc = element.parentElement;
+									let dhops = 0;
+									while (anc && dhops < 12) {
+										const selector = 'img[loading="lazy"], iframe[loading="lazy"], [data-src], [data-srcset], [data-bg], [data-background]';
+										const lazies = anc.querySelectorAll(selector);
+										for (const node of lazies) {
+											const usable = !(node === element || element.contains(node) || node.contains(element) || !isRendered(node));
+											const dpending = node.hasAttribute('data-src') || node.hasAttribute('data-srcset') || node.hasAttribute('data-bg') || node.hasAttribute('data-background') || (node.tagName === 'IMG' && !(node.complete && node.naturalWidth > 0));
+											if (usable && dpending && rectCovers(node.getBoundingClientRect(), dcx, dcy)) {
+												bgDynamicSignal = 'lazy-attr';
+												break;
+											}
+										}
+										if (bgDynamicSignal || anc === window.document.body) {
+											break;
+										}
+										const doverflow = window.getComputedStyle(anc).overflow;
+										if (doverflow && doverflow !== 'visible') {
+											break;
+										}
+										anc = anc.parentElement;
+										dhops += 1;
+									}
+								}
+							}
+							// Tier 2: unmarked media-slot skeleton — a solid full-tile placeholder behind the text
+							// (bgGradient/bgImage incomplete) with no marking attribute; detect the shape.
+							// initial load the tile has a SOLID placeholder slot behind the text plus a gradient overlay,
+							if (!bgImageBehind && !bgDynamicSignal && bbox && bbox.width > 0 && bbox.height > 0) {
+								const mk2 = dataCheck && dataCheck.data && dataCheck.data.messageKey;
+								if (mk2 === 'bgGradient' || mk2 === 'bgImage') {
+									const scx = bbox.x + (bbox.width / 2);
+									const scy = bbox.y + (bbox.height / 2);
+									let shops = 0; let
+										tile = null;
+									for (let anc = element.parentElement; anc && shops < 12; anc = anc.parentElement, shops += 1) {
+										const ts = window.getComputedStyle(anc);
+										const positioned = ts.position === 'relative' || ts.position === 'absolute' || ts.position === 'fixed' || ts.position === 'sticky';
+										if (ts.overflow && ts.overflow !== 'visible' && positioned) {
+											tile = anc;
+											break;
+										}
+										if (anc === window.document.body) {
+											break;
+										}
+									}
+									if (tile) {
+										const tr = tile.getBoundingClientRect();
+										const slots = tile.querySelectorAll('div, span, section, a, picture');
+										for (const el of slots) {
+											const skip = el === element || el.contains(element) || element.contains(el) || !isRendered(el);
+											const slotStyle = skip ? null : window.getComputedStyle(el);
+											const positioned = slotStyle && (slotStyle.position === 'absolute' || slotStyle.position === 'fixed');
+											const rect = positioned ? el.getBoundingClientRect() : null;
+											const bigEnough = rect && rect.width >= tr.width * 0.8 && rect.height >= tr.height * 0.8 && rectCovers(rect, scx, scy);
+											const solid = bigEnough && (slotStyle.backgroundImage || 'none') === 'none' && (/^rgb\(/).test(slotStyle.backgroundColor || '');
+											const empty = solid && !el.querySelector('img, video, canvas') && (el.textContent || '').trim().length === 0;
+											if (empty) {
+												bgDynamicSignal = 'empty-slot';
+												break;
+											}
+										}
+									}
+								}
+							}
+						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;
 						if (messageKey === 'pseudoContent') {
 							// a pseudo carries its own opacity on top of the element-chain
@@ -276,6 +507,11 @@ const run = async options => {
 							bgClip,
 							...(bgImage && {bgImage}),
 							...(bgColor && {bgColor}),
+							...(bgImageBehind && {bgImageBehind: true}),
+							...(bgMediaType && {bgMediaType}),
+							...(bgMediaReady !== null && {bgMediaReady}),
+							...(bgDynamicSignal && {bgDynamicSignal}),
+							...(bgDetectVersion && {bgDetectVersion}),
 							bbox,
 							...(opacity < 1 && {opacity}),
 							...(pseudoBefore && {pseudoBefore}),

--- a/test/unit/lib/runners/axe.test.js
+++ b/test/unit/lib/runners/axe.test.js
@@ -686,4 +686,369 @@ describe('lib/runners/axe', function() {
 		});
 	});
 
+	describe('lib/runners/axe background detection', function() {
+		let originalWindow;
+		let runner;
+		let styleMap;
+
+		function fakeStyle(overrides = {}) {
+			return Object.assign({
+				color: 'rgb(255, 255, 255)',
+				backgroundClip: 'border-box',
+				webkitBackgroundClip: '',
+				backgroundImage: 'none',
+				backgroundColor: 'rgba(0, 0, 0, 0)',
+				opacity: '1',
+				display: 'block',
+				visibility: 'visible',
+				position: 'static',
+				overflow: 'visible',
+				content: 'none',
+				getPropertyValue: () => ''
+			}, overrides);
+		}
+
+		function fakeEl(config = {}) {
+			const rect = config.rect || {x: 10,
+				y: 10,
+				width: 100,
+				height: 30};
+			const el = {
+				nodeType: 1,
+				tagName: config.tagName || 'DIV',
+				parentElement: config.parentElement || null,
+				textContent: config.textContent || '',
+				complete: config.complete,
+				naturalWidth: config.naturalWidth,
+				readyState: config.readyState,
+				value: config.value,
+				placeholder: config.placeholder,
+				mediaChildren: config.media || [],
+				lazyChildren: config.lazies || [],
+				slotChildren: config.slots || [],
+				innerMedia: config.innerMedia || null,
+				getBoundingClientRect() {
+					return {
+						x: rect.x,
+						y: rect.y,
+						width: rect.width,
+						height: rect.height,
+						left: rect.x,
+						top: rect.y,
+						right: rect.x + rect.width,
+						bottom: rect.y + rect.height
+					};
+				},
+				contains() {
+					return false;
+				},
+				getAttribute(name) {
+					return (config.attrs || {})[name] || null;
+				},
+				hasAttribute(name) {
+					return Boolean(config.attrs && Object.prototype.hasOwnProperty.call(config.attrs, name));
+				},
+				querySelectorAll(selector) {
+					if (selector.indexOf('data-src') !== -1) {
+						return el.lazyChildren;
+					}
+					if (selector.indexOf('picture') !== -1) {
+						return el.slotChildren;
+					}
+					return el.mediaChildren;
+				},
+				querySelector() {
+					return el.innerMedia;
+				}
+			};
+			el.placeholderStyle = config.placeholderStyle || null;
+			styleMap.set(el, fakeStyle(config.style));
+			return el;
+		}
+
+		async function detect(element, options = {}) {
+			global.window.innerWidth = options.innerWidth || 1000;
+			global.window.innerHeight = options.innerHeight || 800;
+			global.window.document.elementsFromPoint = sinon.stub().returns(options.elementsFromPoint || []);
+			global.window.document.querySelector = sinon.stub().returns(element);
+			const check = {
+				id: 'color-contrast',
+				data: {messageKey: options.messageKey || 'bgColor'},
+				relatedNodes: []
+			};
+			global.window.axe.run = sinon.stub().resolves({
+				violations: [],
+				incomplete: [
+					{
+						id: 'color-contrast',
+						description: 'd',
+						impact: 'serious',
+						help: 'h',
+						helpUrl: 'u',
+						nodes: [{target: ['sel'],
+							any: [check]}]
+					}
+				]
+			});
+			const resolved = await runner.run({}, {});
+			return resolved[0].runnerExtras;
+		}
+
+		beforeEach(function() {
+			styleMap = new Map();
+			originalWindow = global.window;
+			global.window = {
+				axe: {
+					run: sinon.stub(),
+					getRules: sinon.stub().returns([])
+				},
+				document: {
+					querySelector: sinon.stub(),
+					documentElement: {nodeType: 9,
+						querySelectorAll: () => [],
+						getAttribute: () => null},
+					body: {nodeType: 1,
+						querySelectorAll: () => [],
+						getAttribute: () => null}
+				}
+			};
+			global.window.getComputedStyle = sinon.stub().callsFake((el, pseudo) => {
+				if (pseudo === '::placeholder') {
+					return (el && el.placeholderStyle) || fakeStyle();
+				}
+				if (pseudo === '::before' || pseudo === '::after') {
+					return fakeStyle({content: 'none'});
+				}
+				return styleMap.get(el) || fakeStyle();
+			});
+			runner = require('../../../../lib/runners/axe');
+		});
+
+		afterEach(function() {
+			global.window = originalWindow;
+		});
+
+		it('stamps bgDetectVersion on every color-contrast incomplete', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDetectVersion, 'geom-1');
+		});
+
+		it('flags a stacked <video> that has not decoded a frame (bgMediaReady false)', async function() {
+			const video = fakeEl({tagName: 'VIDEO',
+				readyState: 1});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			const extras = await detect(el, {elementsFromPoint: [video]});
+			assert.isTrue(extras.bgImageBehind);
+			assert.strictEqual(extras.bgMediaType, 'video');
+			assert.isFalse(extras.bgMediaReady);
+		});
+
+		it('treats a stacked url() background layer as an image with no observable load state', async function() {
+			const urlLayer = fakeEl({style: {backgroundImage: 'url(x.png)'}});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			const extras = await detect(el, {elementsFromPoint: [urlLayer]});
+			assert.strictEqual(extras.bgMediaType, 'image');
+			assert.isUndefined(extras.bgMediaReady);
+		});
+
+		it('flags a url() background on an ancestor, passing through a see-through gradient', async function() {
+			const urlAncestor = fakeEl({
+				parentElement: global.window.document.documentElement,
+				style: {backgroundImage: 'url(hero.png)'}
+			});
+			const gradientAncestor = fakeEl({
+				parentElement: urlAncestor,
+				style: {backgroundImage: 'linear-gradient(to top, rgba(0, 0, 0, 0.4), transparent)'}
+			});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: gradientAncestor});
+			const extras = await detect(el);
+			assert.isTrue(extras.bgImageBehind);
+			assert.strictEqual(extras.bgMediaType, 'image');
+		});
+
+		it('stops at an opaque colour ancestor without flagging a background', async function() {
+			const solid = fakeEl({
+				parentElement: global.window.document.documentElement,
+				style: {backgroundColor: 'rgb(5, 5, 5)'}
+			});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: solid});
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgImageBehind);
+			assert.strictEqual(extras.bgDetectVersion, 'geom-1');
+		});
+
+		it('detects a covering <img> below the fold via geometry and reports it loaded', async function() {
+			const img = fakeEl({
+				tagName: 'IMG',
+				complete: true,
+				naturalWidth: 800,
+				rect: {x: 0,
+					y: 0,
+					width: 2000,
+					height: 9000}
+			});
+			const card = fakeEl({parentElement: global.window.document.body,
+				media: [img]});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: card,
+				rect: {x: 100,
+					y: 5000,
+					width: 200,
+					height: 20}});
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgMediaType, 'image');
+			assert.isTrue(extras.bgMediaReady);
+		});
+
+		it('flags an aria-busy region as dynamic content', async function() {
+			const el = fakeEl({
+				tagName: 'H3',
+				parentElement: global.window.document.documentElement,
+				attrs: {'aria-busy': 'true'}
+			});
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'aria-busy');
+		});
+
+		it('flags a lazy-load placeholder covering the text (data-* marker)', async function() {
+			const lazy = fakeEl({
+				rect: {x: 0,
+					y: 0,
+					width: 400,
+					height: 400},
+				attrs: {'data-bg': '/hero.jpg'}
+			});
+			const card = fakeEl({parentElement: global.window.document.documentElement,
+				lazies: [lazy]});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: card});
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'lazy-attr');
+		});
+
+		it('flags an unmarked empty media-slot skeleton (Tier 2) for a bgGradient incomplete', async function() {
+			const slot = fakeEl({
+				rect: {x: 0,
+					y: 0,
+					width: 200,
+					height: 200},
+				style: {position: 'absolute',
+					backgroundColor: 'rgb(230, 230, 230)'}
+			});
+			const tile = fakeEl({
+				parentElement: global.window.document.documentElement,
+				style: {position: 'relative',
+					overflow: 'hidden'},
+				rect: {x: 0,
+					y: 0,
+					width: 200,
+					height: 200},
+				slots: [slot]
+			});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: tile,
+				rect: {x: 40,
+					y: 20,
+					width: 120,
+					height: 15}});
+			const extras = await detect(el, {messageKey: 'bgGradient'});
+			assert.strictEqual(extras.bgDynamicSignal, 'empty-slot');
+		});
+
+		it('captures an empty input placeholder colour as the foreground', async function() {
+			const el = fakeEl({
+				tagName: 'INPUT',
+				value: '',
+				placeholder: 'Search',
+				parentElement: global.window.document.documentElement
+			});
+			el.placeholderStyle = fakeStyle({color: 'rgb(120, 120, 120)',
+				opacity: '0.5'});
+			const extras = await detect(el);
+			assert.strictEqual(extras.placeholderColor, 'rgb(120, 120, 120)');
+			assert.strictEqual(extras.placeholderOpacity, 0.5);
+		});
+
+		it('reports a stacked <canvas> as media treated as ready (no observable load state)', async function() {
+			const canvas = fakeEl({tagName: 'CANVAS'});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			const extras = await detect(el, {elementsFromPoint: [canvas]});
+			assert.strictEqual(extras.bgMediaType, 'canvas');
+			assert.isTrue(extras.bgMediaReady);
+		});
+
+		it('does not flag media when the stacked layer is an opaque colour', async function() {
+			const opaque = fakeEl({style: {backgroundColor: 'rgb(20, 20, 20)'}});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			const extras = await detect(el, {elementsFromPoint: [opaque]});
+			assert.isUndefined(extras.bgMediaType);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('stops the geometry walk at a clip container with no covering media', async function() {
+			const clip = fakeEl({parentElement: global.window.document.body,
+				style: {overflow: 'hidden'}});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: clip,
+				rect: {x: 100,
+					y: 5000,
+					width: 200,
+					height: 20}});
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgMediaType);
+		});
+
+		it('walks the geometry chain to the body without finding covering media', async function() {
+			const mid = fakeEl({parentElement: global.window.document.body});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: mid,
+				rect: {x: 100,
+					y: 5000,
+					width: 200,
+					height: 20}});
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgMediaType);
+		});
+
+		it('does not flag Tier 2 when no clip container is found before the body', async function() {
+			const plain = fakeEl({parentElement: global.window.document.body});
+			const el = fakeEl({tagName: 'H3',
+				parentElement: plain,
+				rect: {x: 40,
+					y: 20,
+					width: 120,
+					height: 15}});
+			const extras = await detect(el, {messageKey: 'bgImage'});
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('captures ::after pseudo styles for a pseudoContent incomplete', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			global.window.getComputedStyle = sinon.stub().callsFake((node, pseudo) => {
+				if (pseudo === '::after') {
+					return fakeStyle({content: '"x"',
+						color: 'rgb(9, 9, 9)'});
+				}
+				if (pseudo === '::before') {
+					return fakeStyle({content: 'none'});
+				}
+				if (pseudo === '::placeholder') {
+					return fakeStyle();
+				}
+				return styleMap.get(node) || fakeStyle();
+			});
+			const extras = await detect(el, {messageKey: 'pseudoContent'});
+			assert.deepEqual(extras.pseudoAfter, {color: 'rgb(9, 9, 9)',
+				content: '"x"'});
+		});
+	});
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enhances color-contrast audits by detecting media backgrounds (img/video/canvas/url()) behind text and capturing load state when available, reducing false results on hero images and lazy content. Addresses DEV-919.

- New Features
  - Detects covering media via ancestor walk, paint stack, and geometry; records `bgImageBehind`, `bgMediaType`, and `bgMediaReady` (null for CSS `url()`).
  - Stops at the first opaque layer; treats translucent gradients as pass-through; ignores hidden/transparent layers.
  - Adds dynamic signals: `aria-busy`, `lazy-attr`, and `empty-slot` to abstain when backgrounds are still loading.
  - Stamps `bgDetectVersion: "geom-1"` on all color-contrast incompletes.

<sup>Written for commit 083e7ceccd51a982ae93c9b5853fb18017b94811. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/darrenbritton/pa11y-unlimited/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

