### PR TITLE
Feat/dev 1200 opacity animation detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.8.0 (2026-07-16)
+
+* Detect an in-flight `opacity` animation or transition on the text or any ancestor of a colour-contrast incomplete — a running WAAPI/CSS opacity animation, a `transition` of `opacity`/`all`, or a `will-change: opacity` reveal caught below its settled value — and emit `bgDynamicSignal: 'opacity-animation'`. Reading `opacity` live during the axe run while the screenshot is captured on a different frame otherwise yields a transient mid-fade value; the signal lets the post-audit colour-contrast resolver abstain instead of scoring a wrong `fail` on scroll-reveal text. (DEV-1200)
+
+### Full diff for `pa11y-unlimited@9.8.0`
+
+* [v9.7.0...v9.8.0](https://github.com/darrenbritton/pa11y-unlimited/compare/v9.7.0...v9.8.0)
+
 ## 9.6.1 (2026-06-30)
 
 * Capture the `::placeholder` colour (and its own opacity) for an empty `<input>`/`<textarea>` — where the placeholder is the only visible text and the element's `color` styles the never-painted typed value — so the post-audit colour-contrast resolver measures the visible placeholder instead of false-passing on the unpainted `color`. (DEV-917)

--- a/lib/runners/axe.js
+++ b/lib/runners/axe.js
@@ -181,6 +181,7 @@ const run = async options => {
 				let pseudoBefore = null;
 				let pseudoAfter = null;
 				let opacity = 1;
+				let opacityAnimating = false;
 				let placeholderColor = null;
 				let placeholderOpacity = 1;
 				if (needsFurtherReview && element) {
@@ -212,12 +213,45 @@ const run = async options => {
 						}
 						// element/ancestor opacity fades the text below its CSS `color`.
 						// Multiply up the chain so the resolver folds it into the fg alpha.
+						// A running opacity animation/transition (or a will-change:opacity reveal caught
+						// mid-fade) means this opacity — and the separately-taken screenshot — are a
+						// transient frame, not the settled value; flag it so the resolver can abstain.
+						const runningOpacityAnimation = anc => {
+							if (typeof anc.getAnimations !== 'function') {
+								return false;
+							}
+							try {
+								return anc.getAnimations().some(animation => {
+									if (animation.playState !== 'running') {
+										return false;
+									}
+									if (animation.transitionProperty) {
+										return animation.transitionProperty === 'opacity' || animation.transitionProperty === 'all';
+									}
+									const effect = animation.effect;
+									return Boolean(effect && typeof effect.getKeyframes === 'function' &&
+										effect.getKeyframes().some(frame => 'opacity' in frame));
+								});
+							} catch {
+								return false;
+							}
+						};
 						let ancestor = element;
 						while (ancestor && ancestor.nodeType === 1) {
 							const ancestorStyle = window.getComputedStyle(ancestor);
 							const ancestorOpacity = ancestorStyle ? parseFloat(ancestorStyle.opacity) : NaN;
 							if (Number.isFinite(ancestorOpacity)) {
 								opacity *= ancestorOpacity;
+							}
+							if (id === 'color-contrast' && !opacityAnimating) {
+								// JS rAF fades (e.g. Webflow IX2) leave no Animation object, but keep
+								// will-change:opacity set while the value is still below its settled target.
+								const willChange = ancestorStyle && ancestorStyle.willChange;
+								const willChangeReveal = Boolean(willChange) && willChange.indexOf('opacity') !== -1 &&
+									Number.isFinite(ancestorOpacity) && ancestorOpacity < 1;
+								if (runningOpacityAnimation(ancestor) || willChangeReveal) {
+									opacityAnimating = true;
+								}
 							}
 							ancestor = ancestor.parentElement;
 						}
@@ -457,6 +491,12 @@ const run = async options => {
 										}
 									}
 								}
+							}
+							// An in-flight opacity animation on the text or an ancestor makes the captured
+							// opacity a transient mid-fade frame — treat it like the other dynamic tells so
+							// the resolver abstains rather than scoring the frame.
+							if (!bgImageBehind && !bgDynamicSignal && opacityAnimating) {
+								bgDynamicSignal = 'opacity-animation';
 							}
 						}
 						const messageKey = dataCheck && dataCheck.data && dataCheck.data.messageKey;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-unlimited",
-  "version": "9.7.0",
+  "version": "9.8.0",
   "description": "Pa11y is your automated accessibility testing pal",
   "keywords": [
     "a11y",

--- a/test/unit/lib/runners/axe.test.js
+++ b/test/unit/lib/runners/axe.test.js
@@ -932,6 +932,98 @@ describe('lib/runners/axe', function() {
 			assert.strictEqual(extras.bgDynamicSignal, 'lazy-attr');
 		});
 
+		it('flags an in-flight opacity transition as dynamic content (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{playState: 'running',
+				transitionProperty: 'opacity'}];
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'opacity-animation');
+		});
+
+		it('flags a transition of "all" that includes opacity (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{playState: 'running',
+				transitionProperty: 'all'}];
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'opacity-animation');
+		});
+
+		it('flags a WAAPI animation whose keyframes tween opacity (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{
+				playState: 'running',
+				effect: {getKeyframes: () => [{opacity: 0},
+					{opacity: 1}]}
+			}];
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'opacity-animation');
+		});
+
+		it('flags a will-change:opacity reveal caught mid-fade with no Animation object (DEV-1200)', async function() {
+			const el = fakeEl({
+				tagName: 'H3',
+				parentElement: global.window.document.documentElement,
+				style: {willChange: 'opacity',
+					opacity: '0.2'}
+			});
+			const extras = await detect(el);
+			assert.strictEqual(extras.bgDynamicSignal, 'opacity-animation');
+			assert.strictEqual(extras.opacity, 0.2);
+		});
+
+		it('does not flag a transition that leaves opacity alone (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{playState: 'running',
+				transitionProperty: 'transform'}];
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('does not flag a WAAPI animation that never touches opacity (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{
+				playState: 'running',
+				effect: {getKeyframes: () => [{transform: 'translateY(0)'}]}
+			}];
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('does not flag a finished (idle) opacity animation (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => [{playState: 'idle',
+				transitionProperty: 'opacity'}];
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('does not flag will-change:opacity once the value has settled (DEV-1200)', async function() {
+			const el = fakeEl({
+				tagName: 'H3',
+				parentElement: global.window.document.documentElement,
+				style: {willChange: 'opacity',
+					opacity: '1'}
+			});
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
+		it('tolerates getAnimations throwing, falling back to no signal (DEV-1200)', async function() {
+			const el = fakeEl({tagName: 'H3',
+				parentElement: global.window.document.documentElement});
+			el.getAnimations = () => {
+				throw new Error('detached');
+			};
+			const extras = await detect(el);
+			assert.isUndefined(extras.bgDynamicSignal);
+		});
+
 		it('flags an unmarked empty media-slot skeleton (Tier 2) for a bgGradient incomplete', async function() {
 			const slot = fakeEl({
 				rect: {x: 0,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Detect in-flight `opacity` animations/transitions and flag them as dynamic so `color-contrast` checks abstain instead of mis-scoring mid-fade text. Implements DEV-1200 to reduce false fails on scroll‑reveal content.

- **New Features**
  - Emit `bgDynamicSignal: 'opacity-animation'` for `color-contrast` when the element or any ancestor is mid-fade via a running CSS transition of `opacity`/`all`, a WAAPI animation that tweens `opacity`, or `will-change: opacity` with computed opacity < 1.
  - Added unit tests for positive and negative cases, including transitions, WAAPI, will-change, idle/finished animations, and error handling.

<sup>Written for commit e43b5e8c84017caf4cc6c2ef949f98063199d438. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/darrenbritton/pa11y-unlimited/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

